### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,9 @@ Install the package in a Laravel Nova project via Composer:
 composer require optimistdigital/nova-locale-manager
 ```
 
-Publish the database migration(s) and run migrate:
+Run the database migration(s):
 
 ```bash
-php artisan vendor:publish --provider="OptimistDigital\NovaLocaleManager\ToolServiceProvider" --tag="migrations"
 php artisan migrate
 ```
 


### PR DESCRIPTION
After this [commit](https://github.com/optimistdigital/nova-locale-manager/commit/98113809870aa4307ad204d17c8ed7922f4a4986) the following command throws an error.

```
php artisan vendor:publish --provider="OptimistDigital\NovaLocaleManager\ToolServiceProvider" --tag="migrations"
```
```
Unable to locate publishable resources.
```

![image](https://user-images.githubusercontent.com/534610/81958842-99ff0100-961f-11ea-8221-ea1edd980ed0.png)


So, this step is not required anymore, since migrations are automatically loaded from `./vendor/optimistdigital/nova-locale-manager/database/migrations` directory.