### PR TITLE
Update spatie/once dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "require": {
     "php": ">=7.1.0",
-    "spatie/once": "^2.2",
+    "spatie/once": "^3.0",
     "laravel/nova": "^2.0.11 || ^3.0",
     "doctrine/dbal": "^2.9"
   },


### PR DESCRIPTION
Update because error in a fresh laravel nova installation
```
optimistdigital/nova-locale-manager[2.0.0, ..., 2.0.3] require spatie/once ^2.2 -> found spatie/once[2.2.0, 2.2.1] but the package is fixed to 3.0.1 (lock file version) by a partial update and that version does not match.
```